### PR TITLE
chore(biome): ignore package.json

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -26,5 +26,13 @@
     "formatter": {
       "quoteStyle": "double"
     }
-  }
+  },
+  "overrides": [
+    {
+      "include": ["**/package.json"],
+      "formatter": {
+        "lineWidth": 1
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Don't trigger Biome formatting errors on `package.json` as it tends to format itself under certain circumstances.